### PR TITLE
Added locale for Months in calendar display

### DIFF
--- a/handlers/commands.js
+++ b/handlers/commands.js
@@ -272,7 +272,7 @@ function generateCalendarCodeblock(guild) {
   for (let i = 0; i < dayMap.length; i++) {
     let key = "day" + String(i);
     let sendString = "";
-    sendString += "\n**" + dayMap[i].toLocaleString({ weekday: "long", locale: guild.lng }) + "** - "+ dayMap[i].toLocaleString({ month: "long", day: "2-digit" });
+    sendString += "\n**" + dayMap[i].toLocaleString({ weekday: "long", locale: guild.lng }) + "** - "+ dayMap[i].toLocaleString({ month: "long", day: "2-digit", locale: guild.lng });
     if (guildSettings.emptydays === "0" && guildCalendar[key].length === 0) continue;
     if (guildCalendar[key].length === 0) {
       sendString += "```\n ```";
@@ -339,7 +339,7 @@ function generateCalendarEmbed(guild) {
     let key = "day" + String(i);
     let tempValue = "";
     let fieldObj = {
-      name: "**" + dayMap[i].toLocaleString({ weekday: "long" }) + "** - " + dayMap[i].toLocaleString({ month: "long", day: "2-digit"}),
+      name: "**" + dayMap[i].toLocaleString({ weekday: "long", locale: guild.lng }) + "** - " + dayMap[i].toLocaleString({ month: "long", day: "2-digit", locale: guild.lng }),
       inline: (guildSettings.inline === "1")
     };
     if (guildSettings.emptydays === "0" && guildCalendar[key].length === 0) continue;


### PR DESCRIPTION
Fixed:
- Days not translated in the embed calendar display when using different locale
- Months not translated in embed/codeblock calendar display when using different locale