### PR TITLE
Add discord timestamp to the embedded calendar post.

### DIFF
--- a/handlers/commands.js
+++ b/handlers/commands.js
@@ -323,6 +323,21 @@ function durationString(event, guild) {
 }
 
 /**
+ * Creates event discord timestamp
+ * @param {Event} event - Event to create for
+ * @returns {String}
+ */
+function generateEventTimeStamp(event, guild) {
+  // check for early exit condition
+  // middle of multi-day or no time, return empty string
+  if (Object.keys(event.start).includes("date") || event.type === eventType.MULTIMID) return "";
+  // event must have dateTime
+  const zDate = DateTime.fromISO(event.start.dateTime, {setZone: true});
+  const timestamp = date.getTime();
+  return `<t:${timestamp}:R>`;
+}
+
+/**
  * Generate codeblock messsage for calendar display
  * @param {Guild} guild - guild to create for
  */
@@ -381,7 +396,8 @@ function embedEventString(event, guild) {
   const guildSettings = guild.getSetting();
   const duration = durationString(event, guild);
   const eventTitle = eventNameCreator(event, guildSettings); // add link if there is a location
-  let eventString = (guildSettings.eventtime === "1" ? `**${duration}** | ${eventTitle}\n`: `${eventTitle}\n`);
+  const eventTimeStamp = generateEventTimeStamp(event);
+  let eventString = (guildSettings.eventtime === "1" ? `**${duration}** | ${eventTitle} ${eventTimeStamp}\n`: `${eventTitle}\n`);
   // limit description length
   const descLength = guildSettings.descLength;
   const description = event.description;

--- a/handlers/commands.js
+++ b/handlers/commands.js
@@ -396,7 +396,7 @@ function embedEventString(event, guild) {
   const guildSettings = guild.getSetting();
   const duration = durationString(event, guild);
   const eventTitle = eventNameCreator(event, guildSettings); // add link if there is a location
-  const eventTimeStamp = generateEventTimeStamp(event);
+  const eventTimeStamp = (guildSettings.timestamp === "1" ? generateEventTimeStamp(event): '');
   let eventString = (guildSettings.eventtime === "1" ? `**${duration}** | ${eventTitle} ${eventTimeStamp}\n`: `${eventTitle}\n`);
   // limit description length
   const descLength = guildSettings.descLength;

--- a/handlers/commands.js
+++ b/handlers/commands.js
@@ -327,7 +327,7 @@ function durationString(event, guild) {
  * @param {Event} event - Event to create for
  * @returns {String}
  */
-function generateEventTimeStamp(event, guild) {
+function generateEventTimeStamp(event) {
   // check for early exit condition
   // middle of multi-day or no time, return empty string
   if (Object.keys(event.start).includes("date") || event.type === eventType.MULTIMID) return "";

--- a/handlers/commands.js
+++ b/handlers/commands.js
@@ -333,7 +333,7 @@ function generateEventTimeStamp(event, guild) {
   if (Object.keys(event.start).includes("date") || event.type === eventType.MULTIMID) return "";
   // event must have dateTime
   const zDate = DateTime.fromISO(event.start.dateTime, {setZone: true});
-  const timestamp = date.getTime();
+  const timestamp = zDate.toSeconds();
   return `<t:${timestamp}:R>`;
 }
 

--- a/handlers/displayoptions.js
+++ b/handlers/displayoptions.js
@@ -71,6 +71,9 @@ const doHelpArray = {
     name: "days",
     default: 7,
     max: 60
+  }, timestamp: {
+    type: "binaryNumber",
+    name: "timestamp",
   }
 };
 

--- a/handlers/guilds.js
+++ b/handlers/guilds.js
@@ -44,7 +44,8 @@ const defaultSettings = {
   "startonly": "0",
   "eventtime": "1",
   "lng": "en",
-  "lasterr": ""
+  "lasterr": "",
+  "timestamp": "1",
 };
 
 /**

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -117,6 +117,7 @@ displayoptions:
       !displayoptions url          (0|1)         hide/show "location" as embedded link (embed only)
       !displayoptions startonly    (0|1)         only show start time
       !displayoptions eventtime    (0|1)         don't show event time
+      !displayoptions timestamp    (0|1)         hide/show discord timestamp after the event description (embed only)
       !displayoptions desclength   (n)           trim description to n characters (0 =  off)
     ```
 

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -75,6 +75,7 @@ displayoptions:
     confirmOff: Set {{help}} off
     pin: calendar pinning
     tzDisplay: calendar timezone display
+    timestamp: timestamp display
     emptydays: calendar empty days
     showpast: display of today's past events
     startonly: start time only


### PR DESCRIPTION
Add the feature to have the discord timestamp of the starting time of the event and the end of the event description so that  people can easily check the time of the events in their own timezone. As shown in the below screenshot. This only works for the embed style of the calendar message though, since in code style the discord timestamp format is ignored by discord. As requested in Issue #208.

<img width="357" alt="Screen Shot 2022-06-15 at 8 34 36 AM" src="https://user-images.githubusercontent.com/17034696/173711955-3007b605-c527-43dd-aabc-8a7f58afefdd.png">
